### PR TITLE
Version 0.1.2 is not published

### DIFF
--- a/sbt-plugin/README.md
+++ b/sbt-plugin/README.md
@@ -11,7 +11,7 @@ sbt.version = 1.0.3
 ```
 Add the plugin to `project/plugins.sbt`:
 ```
-addSbtPlugin("io.github.sugakandrey" % "sbt-scalamu" % "0.1.2")
+addSbtPlugin("io.github.sugakandrey" % "sbt-scalamu" % "0.1.1")
 ```
 Execute `scalamuRun` command inside SBT shell:
 ```


### PR DESCRIPTION
When I try to download the `0.1.2` version of the sbt plugin, sbt cannot find the package. If I switch to `0.1.1`, the plugin is dowloaded without problems.